### PR TITLE
Language dropdown set correctly if `lang` present in query string

### DIFF
--- a/templates/edit/edit.html
+++ b/templates/edit/edit.html
@@ -8,9 +8,9 @@
             <select name="extension" id="extension" aria-label="Code Language">
                 {% for option in form.extension %}
                     {% if loop.first %}
-                        <option value="" disabled selected>select language</option>
+                        <option value="" disabled{% if not lang %} selected{% endif %}>select language</option>
                     {% else %}
-                        {{ option }}
+                        <option value="{{ option.data }}"{% if lang == option.data %} selected{% endif %}>{{ option.label.text }}</option>
                     {% endif %}
                 {% endfor %}
             </select>


### PR DESCRIPTION
When cloning & editing, quickpaste sets `lang` variable but doesn't populate the select dropdown menu from this variable. It's a minor inconvenience; Pygments can auto-detect the language probably. But it's a simple fix.